### PR TITLE
fix(ci): Added a login to the private gh registry

### DIFF
--- a/.github/workflows/github-action-test-apax.yml
+++ b/.github/workflows/github-action-test-apax.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           apax-access-token: ${{ secrets.APAX_TOKEN }}
 
+      - name: "Login to the private repo"
+        run: |
+          apax login \
+          --registry "https://npm.pkg.github.com" \
+          --password ${{ secrets.CI_KIT_TOKEN }}
+
       - name: "Build apax library"
         uses: ./actions/.github/actions/apax-build
         with:
@@ -59,6 +65,12 @@ jobs:
         uses: ./actions/.github/actions/setup-apax-runner
         with:
           apax-access-token: ${{ secrets.APAX_TOKEN }}
+
+      - name: "Login to the private repo"
+        run: |
+          apax login \
+          --registry "https://npm.pkg.github.com" \
+          --password ${{ secrets.CI_KIT_TOKEN }}
 
       - name: "Install workspace dependencies and test"
         uses: ./actions/.github/actions/apax-test


### PR DESCRIPTION
Added an apax login to both the build and test action in order to create a login token before the installation of dependencies actually happens.
